### PR TITLE
QnA Maker location update to westus

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -539,7 +539,7 @@
             "type": "Microsoft.CognitiveServices/accounts",
             "apiVersion": "2017-04-18",
             "name": "[variables('qnaMakerAccountName')]",
-            "location": "[parameters('location')]",
+            "location": "westus",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/Sites', variables('qnaMakerAppServiceName'))]",
                 "[resourceId('Microsoft.Search/searchServices/', variables('azureSearchName'))]",


### PR DESCRIPTION
[Fix] - QnA Maker management service is provisioned in westus only and should not be read from ARM deployment variable parameter